### PR TITLE
feat: update note sidebar item with actions items [#5]

### DIFF
--- a/src/components/sidebar/file-tree-dropdown-menu.tsx
+++ b/src/components/sidebar/file-tree-dropdown-menu.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import {
+  HiDocumentPlus,
+  HiFolderPlus,
+  HiPencil,
+  HiTrash,
+  HiArrowRightOnRectangle,
+} from "react-icons/hi2";
+import { HiDotsVertical } from "react-icons/hi";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { FileNode } from "@/utils/build-tree";
+
+interface FileTreeDropdownMenuProps {
+  node: FileNode;
+  isDir: boolean;
+  startRename: (path: string, currentName: string) => void;
+  setConfirmingDeletePath: (path: string) => void;
+  setMovingFilePath: (path: string) => void;
+  onCreateFileInFolder?: (folderPath: string) => void;
+  onCreateFolderInFolder?: (folderPath: string) => void;
+}
+
+export const FileTreeDropdownMenu: React.FC<FileTreeDropdownMenuProps> = ({
+  node,
+  isDir,
+  startRename,
+  setConfirmingDeletePath,
+  setMovingFilePath,
+  onCreateFileInFolder,
+  onCreateFolderInFolder,
+}) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger>
+        <HiDotsVertical className="text-base text-zinc-300 cursor-pointer" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-32 dark">
+        {isDir && (
+          <>
+            <DropdownMenuItem onClick={() => onCreateFileInFolder?.(node.path)}>
+              <HiDocumentPlus className="mr-2" /> New File
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => onCreateFolderInFolder?.(node.path)}
+            >
+              <HiFolderPlus className="mr-2" /> New Folder
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
+        <DropdownMenuItem onClick={() => startRename(node.path, node.name)}>
+          <HiPencil className="mr-2" /> Rename
+        </DropdownMenuItem>
+
+        {!isDir && (
+          <DropdownMenuItem onClick={() => setMovingFilePath(node.path)}>
+            <HiArrowRightOnRectangle className="mr-2" /> Move to Folder
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem onClick={() => setConfirmingDeletePath(node.path)}>
+          <HiTrash className="mr-2" /> Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/sidebar/sortable-item.tsx
+++ b/src/components/sidebar/sortable-item.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import {
   HiDocument,
   HiFolder,
@@ -10,16 +10,25 @@ import {
   HiFolderPlus,
   HiChevronDown,
   HiChevronRight,
-} from 'react-icons/hi2';
+} from "react-icons/hi2";
+import { HiDotsVertical } from "react-icons/hi";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { FileTreeDropdownMenu } from "./file-tree-dropdown-menu";
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuTrigger,
   ContextMenuSeparator,
-} from '@/components/ui/context-menu';
-import { FileNode } from '@/utils/build-tree';
-import { motion } from 'framer-motion';
+} from "@/components/ui/context-menu";
+import { FileNode } from "@/utils/build-tree";
+import { motion } from "framer-motion";
+import { DropdownMenuSeparator } from "@radix-ui/react-dropdown-menu";
 
 interface FileTreeItemProps {
   node: FileNode;
@@ -71,20 +80,22 @@ export const FileTreeItem: React.FC<FileTreeItemProps> = ({
       animate={{ opacity: 1, x: 0 }}
       transition={{
         duration: 0.2,
-        ease: 'easeOut',
+        ease: "easeOut",
         delay: index * 0.03, // Stagger animation
       }}
-      className="w-full">
+      className="w-full"
+    >
       <ContextMenu key={node.path}>
         <ContextMenuTrigger
           asChild
-          className="flex items-center justify-start gap-2 w-full">
+          className="flex items-center justify-start gap-2 w-full"
+        >
           <div
             style={style}
             className={`flex items-center justify-start gap-2 --text-sm cursor-pointer rounded-md w-full p-2 transition-colors duration-150 ${
               isSelected
-                ? 'bg-zinc-800 text-white'
-                : 'text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200'
+                ? "bg-zinc-800 text-white"
+                : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
             }`}
             onClick={() => {
               if (isDir) {
@@ -92,7 +103,8 @@ export const FileTreeItem: React.FC<FileTreeItemProps> = ({
               } else {
                 onFileSelected(node.path);
               }
-            }}>
+            }}
+          >
             <div className="flex items-center justify-start gap-2 overflow-hidden w-full">
               {isDir && (
                 <div className="flex items-center">
@@ -117,17 +129,28 @@ export const FileTreeItem: React.FC<FileTreeItemProps> = ({
             {hasUnsaved && !isDir && (
               <span className="text-green-400 ml-auto">●</span>
             )}
+            <FileTreeDropdownMenu
+              node={node}
+              isDir={isDir}
+              startRename={startRename}
+              setConfirmingDeletePath={setConfirmingDeletePath}
+              setMovingFilePath={setMovingFilePath}
+              onCreateFileInFolder={onCreateFileInFolder}
+              onCreateFolderInFolder={onCreateFolderInFolder}
+            />
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent className="w-48 dark">
           {isDir && (
             <>
               <ContextMenuItem
-                onClick={() => onCreateFileInFolder?.(node.path)}>
+                onClick={() => onCreateFileInFolder?.(node.path)}
+              >
                 <HiDocumentPlus className="mr-2" /> New File
               </ContextMenuItem>
               <ContextMenuItem
-                onClick={() => onCreateFolderInFolder?.(node.path)}>
+                onClick={() => onCreateFolderInFolder?.(node.path)}
+              >
                 <HiFolderPlus className="mr-2" /> New Folder
               </ContextMenuItem>
               <ContextMenuSeparator />


### PR DESCRIPTION
Adding a "more" action icon on the notes/folder sidebar item for easier more understandable user experience
Issue link : [https://github.com/Hussseinkizz/writter-desktop/issues/5](https://github.com/Hussseinkizz/writter-desktop/issues/5)

**Solution**
- Adding a dropdown component with the exact actions on the `ContextMenuContent` for both folders and files