### PR TITLE
 feat: Add Shortcuts support

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -95,6 +95,64 @@ fn get_command_line_args() -> Vec<String> {
     std::env::args().collect()
 }
 
+#[derive(serde::Serialize, Clone)]
+struct ShortcutInfo {
+    keys: String,
+    description: String,
+    category: String,
+}
+
+#[tauri::command]
+fn get_keyboard_shortcuts() -> Vec<ShortcutInfo> {
+    vec![
+        ShortcutInfo {
+            keys: "Ctrl+S / Cmd+S".to_string(),
+            description: "Save current file".to_string(),
+            category: "File".to_string(),
+        },
+        ShortcutInfo {
+            keys: "Ctrl+N / Cmd+N".to_string(),
+            description: "Create new file".to_string(),
+            category: "File".to_string(),
+        },
+        ShortcutInfo {
+            keys: "Ctrl+Shift+N".to_string(),
+            description: "Create new folder".to_string(),
+            category: "File".to_string(),
+        },
+        ShortcutInfo {
+            keys: "Ctrl+P / Cmd+P".to_string(),
+            description: "Toggle preview".to_string(),
+            category: "View".to_string(),
+        },
+        ShortcutInfo {
+            keys: "Ctrl+B / Cmd+B".to_string(),
+            description: "Bold selected text".to_string(),
+            category: "Formatting".to_string(),
+        },
+        ShortcutInfo {
+            keys: "Ctrl+I / Cmd+I".to_string(),
+            description: "Italic selected text".to_string(),
+            category: "Formatting".to_string(),
+        },
+        ShortcutInfo {
+            keys: "Ctrl+K / Cmd+K".to_string(),
+            description: "Insert link".to_string(),
+            category: "Formatting".to_string(),
+        },
+        ShortcutInfo {
+            keys: "Ctrl+Shift+H".to_string(),
+            description: "Toggle heading (cycles H1 → H6 → off)".to_string(),
+            category: "Formatting".to_string(),
+        },
+        ShortcutInfo {
+            keys: "Ctrl+Shift+? / Ctrl+Shift+/".to_string(),
+            description: "Show keyboard shortcuts".to_string(),
+            category: "Help".to_string(),
+        },
+    ]
+}
+
 /// Handle file opening when app is opened with a file argument
 fn handle_file_open_request(app: &AppHandle, file_path: &str) {
     // Emit an event to the frontend with the file path to open
@@ -120,7 +178,8 @@ pub fn run() {
             create_file,
             create_folder,
             read_directory,
-            get_command_line_args
+            get_command_line_args,
+            get_keyboard_shortcuts
         ])
         .setup(|app| {
             // Check for command line arguments on startup

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,9 @@ import {
   createFolder,
 } from '@/utils/file-handlers';
 import { useSettings } from '@/hooks/use-settings';
+import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts';
 import { LoadingScreen } from './components/loading-screen';
+import { KeyboardShortcutsDialog } from './components/keyboard-shortcuts-dialog';
 import { pluginManager } from '@/plugins/plugin-manager';
 import { builtInPlugins } from '@/plugins/built-in-plugins';
 
@@ -51,6 +53,10 @@ function App() {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [unsavedPaths, setUnsavedPaths] = useState<string[]>([]);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const handleTogglePreview = useCallback(
+    () => setIsPreviewOpen((v) => !v),
+    []
+  );
   const [projectName, setProjectName] = useState<string>('Unknown');
   const [currentFile, setCurrentFile] = useState<string>('Unknown');
   const [musicPlaying, setMusicPlaying] = useState<boolean>(false);
@@ -182,17 +188,6 @@ function App() {
     [selectedPath, unsavedPaths, saveCurrentFile, projectDir]
   );
 
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's') {
-        e.preventDefault();
-        handleSaveFile();
-      }
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [handleSaveFile]);
-
   const handleRename = async (path: string, newName: string) => {
     const parentDir = path.substring(0, path.lastIndexOf('/'));
     const newPath = `${parentDir}/${newName}`;
@@ -278,6 +273,14 @@ function App() {
     setCreateFolderParentPath(folderPath);
     setCreateFolderOpen(true);
   };
+
+  useKeyboardShortcuts({
+    onSave: handleSaveFile,
+    onTogglePreview: handleTogglePreview,
+    onNewFile: showCreateFileDialog,
+    onNewFolder: showCreateFolderDialog,
+    onShowShortcuts: () => setShortcutsOpen(true),
+  });
 
   const confirmCreateFile = async () => {
     if (!newFileName.trim()) {
@@ -373,6 +376,7 @@ function App() {
 
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [notifications, setNotifications] = useState<Notification[]>([
     {
       id: '1',
@@ -519,7 +523,7 @@ function App() {
         <AppHeader
           selectedPath={!!selectedPath}
           showPreview={isPreviewOpen}
-          togglePreview={() => setIsPreviewOpen(!isPreviewOpen)}
+          togglePreview={handleTogglePreview}
           musicPlaying={musicPlaying}
           currentFile={currentFile}
           projectName={projectName}
@@ -528,6 +532,7 @@ function App() {
           onAutoSave={setAutoSave}
           onInsertContent={handleInsertContent}
           onMusicStateChange={handleMusicStateChange}
+          onShowShortcuts={() => setShortcutsOpen(true)}
         />
         <main className="flex h-[90vh] w-full flex-auto items-center justify-center overflow-hidden bg-zinc-900 text-white">
           <ViewLayout
@@ -579,8 +584,13 @@ function App() {
         errorMessage={createFolderError}
       />
 
+      <KeyboardShortcutsDialog
+        open={shortcutsOpen}
+        onOpenChange={setShortcutsOpen}
+      />
+
       {/* TODO: Uncomment when settings functionality is ready
-      <SettingsDialog 
+      <SettingsDialog
         open={settingsOpen}
         onOpenChange={setSettingsOpen}
         trigger={null}

--- a/src/components/ace-editor.tsx
+++ b/src/components/ace-editor.tsx
@@ -16,8 +16,81 @@ import "ace-builds/src-noconflict/ext-linking";
 type EditorProps = {
   value: string;
   onChange: (value: string) => void;
-  theme?: string; // Allow theme switching
+  theme?: string;
 };
+
+// Wrap selection with prefix/suffix, or insert both with cursor placed inside
+function wrapOrInsert(editor: any, prefix: string, suffix: string) {
+  const selection = editor.getSelectedText();
+  if (selection) {
+    const range = editor.selection.getRange();
+    editor.session.replace(range, `${prefix}${selection}${suffix}`);
+  } else {
+    const cursor = editor.getCursorPosition();
+    editor.session.insert(cursor, `${prefix}${suffix}`);
+    editor.moveCursorTo(cursor.row, cursor.column + prefix.length);
+  }
+}
+
+const editorFormattingCommands = [
+  {
+    name: "bold",
+    bindKey: { win: "Ctrl-B", mac: "Command-B" },
+    exec: (editor: any) => wrapOrInsert(editor, "**", "**"),
+  },
+  {
+    name: "italic",
+    bindKey: { win: "Ctrl-I", mac: "Command-I" },
+    exec: (editor: any) => wrapOrInsert(editor, "*", "*"),
+  },
+  {
+    name: "link",
+    bindKey: { win: "Ctrl-K", mac: "Command-K" },
+    exec: (editor: any) => {
+      const selection = editor.getSelectedText();
+      const cursor = editor.getCursorPosition();
+      if (selection) {
+        const range = editor.selection.getRange();
+        editor.session.replace(range, `[${selection}](url)`);
+      } else {
+        editor.session.insert(cursor, "[text](url)");
+        // Place cursor on "text" so it can be replaced immediately
+        editor.moveCursorTo(cursor.row, cursor.column + 1);
+        editor.selection.selectTo(cursor.row, cursor.column + 5);
+      }
+    },
+  },
+  {
+    name: "heading",
+    bindKey: { win: "Ctrl-Shift-H", mac: "Command-Shift-H" },
+    exec: (editor: any) => {
+      const cursor = editor.getCursorPosition();
+      const line = editor.session.getLine(cursor.row);
+      const headingMatch = line.match(/^(#{1,6}) /);
+      if (!headingMatch) {
+        editor.session.insert({ row: cursor.row, column: 0 }, "# ");
+      } else if (headingMatch[1].length < 6) {
+        const oldLen = headingMatch[1].length;
+        editor.session.replace(
+          {
+            start: { row: cursor.row, column: 0 },
+            end: { row: cursor.row, column: oldLen },
+          },
+          headingMatch[1] + "#"
+        );
+      } else {
+        // Remove heading prefix (6 hashes + space = 7 chars)
+        editor.session.replace(
+          {
+            start: { row: cursor.row, column: 0 },
+            end: { row: cursor.row, column: 7 },
+          },
+          ""
+        );
+      }
+    },
+  },
+];
 
 export const MarkdownEditor = ({
   value,
@@ -47,6 +120,7 @@ export const MarkdownEditor = ({
         value={value}
         onChange={onChange}
         name="markdown-editor"
+        commands={editorFormattingCommands}
         editorProps={{
           $blockScrolling: Infinity,
           $useWorker: false,

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -12,6 +12,7 @@ import {
   HiMenu,
   HiInformationCircle,
 } from 'react-icons/hi';
+import { Keyboard } from 'lucide-react';
 import { useState } from 'react';
 import { format } from 'date-fns-tz';
 import { motion } from 'framer-motion';
@@ -102,6 +103,7 @@ type HeaderProps = {
   onInsertContent: (content: string) => void;
   onMusicStateChange: (playing: boolean) => void;
   musicPlaying: boolean;
+  onShowShortcuts?: () => void;
 };
 
 export function AppHeader({
@@ -116,6 +118,7 @@ export function AppHeader({
   onInsertContent,
   onMusicStateChange,
   musicPlaying,
+  onShowShortcuts,
 }: HeaderProps) {
   const [saving, setSaving] = useState(false);
 
@@ -325,6 +328,17 @@ export function AppHeader({
               className="flex items-center gap-3 cursor-pointer hover:bg-neutral-800">
               <HiClipboardList className="h-4 w-4 text-neutral-400" />
               <span>Todo Manager</span>
+            </DropdownMenuItem>
+
+            <DropdownMenuSeparator className="bg-neutral-700" />
+
+            {/* Keyboard Shortcuts */}
+            <DropdownMenuItem
+              onClick={onShowShortcuts}
+              className="flex items-center gap-3 cursor-pointer hover:bg-neutral-800">
+              <Keyboard className="h-4 w-4 text-violet-400" />
+              <span>Keyboard Shortcuts</span>
+              <span className="ml-auto text-[10px] text-neutral-500">Ctrl+Shift+?</span>
             </DropdownMenuItem>
 
             <DropdownMenuSeparator className="bg-neutral-700" />

--- a/src/components/keyboard-shortcuts-dialog.tsx
+++ b/src/components/keyboard-shortcuts-dialog.tsx
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import { Kbd } from './ui/kbd';
+
+type ShortcutInfo = {
+  keys: string;
+  description: string;
+  category: string;
+};
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function KeyboardShortcutsDialog({ open, onOpenChange }: Props) {
+  const [shortcuts, setShortcuts] = useState<ShortcutInfo[]>([]);
+
+  useEffect(() => {
+    if (open && shortcuts.length === 0) {
+      invoke<ShortcutInfo[]>('get_keyboard_shortcuts')
+        .then(setShortcuts)
+        .catch(() => {});
+    }
+  }, [open]);
+
+  const grouped = shortcuts.reduce<Record<string, ShortcutInfo[]>>(
+    (acc, s) => {
+      if (!acc[s.category]) acc[s.category] = [];
+      acc[s.category].push(s);
+      return acc;
+    },
+    {}
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-neutral-900 border-neutral-700 text-neutral-200 max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-violet-400 text-base">
+            Keyboard Shortcuts
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-5 mt-1 max-h-[60vh] overflow-y-auto pr-1">
+          {Object.entries(grouped).map(([category, items]) => (
+            <div key={category}>
+              <h3 className="text-[10px] font-semibold uppercase tracking-widest text-neutral-500 mb-2">
+                {category}
+              </h3>
+              <div className="space-y-2">
+                {items.map((s) => (
+                  <div
+                    key={s.keys}
+                    className="flex items-center justify-between gap-4">
+                    <span className="text-sm text-neutral-300">
+                      {s.description}
+                    </span>
+                    <Kbd className="shrink-0 text-[10px] px-2 py-0.5 h-auto">
+                      {s.keys}
+                    </Kbd>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/use-keyboard-shortcuts.tsx
+++ b/src/hooks/use-keyboard-shortcuts.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import hotkeys from 'hotkeys-js';
+
+type ShortcutHandlers = {
+  onSave: () => void;
+  onTogglePreview: () => void;
+  onNewFile: () => void;
+  onNewFolder: () => void;
+  onShowShortcuts: () => void;
+};
+
+export function useKeyboardShortcuts({
+  onSave,
+  onTogglePreview,
+  onNewFile,
+  onNewFolder,
+  onShowShortcuts,
+}: ShortcutHandlers) {
+  useEffect(() => {
+    // Allow hotkeys to fire even when the Ace editor textarea is focused
+    hotkeys.filter = () => true;
+
+    hotkeys('ctrl+s,command+s', (e) => {
+      e.preventDefault();
+      onSave();
+    });
+
+    hotkeys('ctrl+p,command+p', (e) => {
+      e.preventDefault();
+      onTogglePreview();
+    });
+
+    hotkeys('ctrl+n,command+n', (e) => {
+      e.preventDefault();
+      onNewFile();
+    });
+
+    hotkeys('ctrl+shift+n', (e) => {
+      e.preventDefault();
+      onNewFolder();
+    });
+
+    hotkeys('ctrl+shift+?,ctrl+shift+/', (e) => {
+      e.preventDefault();
+      onShowShortcuts();
+    });
+
+    return () => {
+      hotkeys.unbind('ctrl+s,command+s');
+      hotkeys.unbind('ctrl+p,command+p');
+      hotkeys.unbind('ctrl+n,command+n');
+      hotkeys.unbind('ctrl+shift+n');
+      hotkeys.unbind('ctrl+shift+?,ctrl+shift+/');
+    };
+  }, [onSave, onTogglePreview, onNewFile, onNewFolder, onShowShortcuts]);
+}


### PR DESCRIPTION
Adds a centralized keyboard shortcut system with both app-level and editor-level shortcuts.                                                                                             
  
  Rust
  - New get_keyboard_shortcuts Tauri command it serves as the authoritative shortcut registry, returning structured data (keys, description, category) consumed by the frontend help       
  dialog.

  App-level shortcuts (via hotkeys-js)

<img width="529" height="463" alt="image" src="https://github.com/user-attachments/assets/d22d71d0-36f7-4a83-b2f7-dd332b0e3083" />
